### PR TITLE
Add ignore-case choice to the StringMatcher

### DIFF
--- a/src/main/java/net/obvj/junit/utils/matchers/StringMatcher.java
+++ b/src/main/java/net/obvj/junit/utils/matchers/StringMatcher.java
@@ -92,8 +92,8 @@ public class StringMatcher extends TypeSafeDiagnosingMatcher<String>
          * Execute the matcher business logic.
          *
          * @param string       the string to be evaluated
-         * @param caseStrategy the case strategy to be used
          * @param substrings   the substrings to be checked
+         * @param caseStrategy the case strategy to be used
          * @param mismatch     the description to be used for reporting in case of mismatch
          */
         public abstract boolean evaluate(String string, List<String> substrings, CaseStrategy caseStrategy,
@@ -140,7 +140,7 @@ public class StringMatcher extends TypeSafeDiagnosingMatcher<String>
          * Checks if a string contains a substring.
          *
          * @param string    the string to check
-         * @param substring the string to find
+         * @param substring the substring to find
          * @return {@code true} if the string contains the substring, otherwise {@code false}
          */
         public abstract boolean contains(String string, String substring);
@@ -154,8 +154,9 @@ public class StringMatcher extends TypeSafeDiagnosingMatcher<String>
     /**
      * Builds this Matcher with a specialized strategy and a list of substrings to be tested.
      *
-     * @param strategy   the evaluation strategy
-     * @param substrings the substrings to be evaluated
+     * @param strategy     the evaluation strategy
+     * @param caseStrategy the case strategy to set
+     * @param substrings   the substrings to be evaluated
      */
     private StringMatcher(Strategy strategy, CaseStrategy caseStrategy, String... substrings)
     {

--- a/src/test/java/net/obvj/junit/utils/matchers/StringMatcherTest.java
+++ b/src/test/java/net/obvj/junit/utils/matchers/StringMatcherTest.java
@@ -20,6 +20,7 @@ public class StringMatcherTest
     private static final String FOX = "fox";
     private static final String DRAGON = "dragon";
     private static final String MANTICORE = "manticore";
+    private static final String LAZY_UPPER = "LAZY";
 
     @Test
     public void containsAll_allSubstringsFound_suceeds()
@@ -61,6 +62,19 @@ public class StringMatcherTest
     public void containsNone_unexpectedString_fails()
     {
         assertThat(THE_QUICK_BROWN_FOX, containsNone(DRAGON, MANTICORE, DOG));
+    }
+
+    @Test
+    public void ignoreCase_substringMatches_success()
+    {
+        assertThat(THE_QUICK_BROWN_FOX, containsAll(LAZY_UPPER).ignoreCase());
+        assertThat(THE_QUICK_BROWN_FOX, containsAny(LAZY_UPPER).ignoreCase());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void ignoreCase_substringNotMatches_fails()
+    {
+        assertThat(THE_QUICK_BROWN_FOX, containsAll(DRAGON).ignoreCase());
     }
 
 }


### PR DESCRIPTION
The purpose of this enhancement is to implement a choice to ignore the case of an examined string inside the existing StringMatcher. For example:
```java
assertThat("The text", containsAll("the", "text").ignoreCase());
````