### PR TITLE
Nested exception matcher for cause validation

### DIFF
--- a/src/main/java/net/obvj/junit/utils/matchers/AdvancedMatchers.java
+++ b/src/main/java/net/obvj/junit/utils/matchers/AdvancedMatchers.java
@@ -16,6 +16,7 @@
 
 package net.obvj.junit.utils.matchers;
 
+import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 
 import net.obvj.junit.utils.Procedure;
@@ -168,6 +169,34 @@ public class AdvancedMatchers
     public static Matcher<Procedure> throwsNoException()
     {
         return ExceptionMatcher.throwsNoException();
+    }
+
+    /**
+     * This method behaves exactly the same as calling
+     * {@link AdvancedMatchers#throwsException(Class)}.
+     * <p>
+     * It was created primarily to allow a nested {@code ExceptionMatcher} for the cause of an
+     * exception.
+     * <p>
+     * For example:
+     *
+     * <pre>
+     * {@code assertThat(() -> obj.doStuff("p1"),
+     *         throwsException(IllegalArgumentException.class)
+     *             .withCause(
+     *                 exception(FileNotFoundException.class)
+     *                     .withMessage("File p1 not found"));}
+     * </pre>
+     *
+     * @param exception the expected exception class. A null value is allowed, and means that
+     *                  no exception is expected
+     * @return the matcher
+     * @since 1.6.0
+     * @see AdvancedMatchers#throwsException(Class)
+     */
+    public static ExceptionMatcher exception(Class<? extends Exception> exception)
+    {
+        return ExceptionMatcher.exception(exception);
     }
 
     /**

--- a/src/main/java/net/obvj/junit/utils/matchers/AdvancedMatchers.java
+++ b/src/main/java/net/obvj/junit/utils/matchers/AdvancedMatchers.java
@@ -16,7 +16,6 @@
 
 package net.obvj.junit.utils.matchers;
 
-import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 
 import net.obvj.junit.utils.Procedure;

--- a/src/main/java/net/obvj/junit/utils/matchers/AdvancedMatchers.java
+++ b/src/main/java/net/obvj/junit/utils/matchers/AdvancedMatchers.java
@@ -174,8 +174,8 @@ public class AdvancedMatchers
      * This method behaves exactly the same as calling
      * {@link AdvancedMatchers#throwsException(Class)}.
      * <p>
-     * It was created primarily to allow a nested {@code ExceptionMatcher} for the cause of an
-     * exception.
+     * It was created primarily to allow a nested {@code ExceptionMatcher} to validate the
+     * cause of an exception.
      * <p>
      * For example:
      *
@@ -189,7 +189,7 @@ public class AdvancedMatchers
      *
      * @param exception the expected exception class. A null value is allowed, and means that
      *                  no exception is expected
-     * @return the matcher
+     * @return a new matcher
      * @since 1.6.0
      * @see AdvancedMatchers#throwsException(Class)
      */

--- a/src/main/java/net/obvj/junit/utils/matchers/ExceptionMatcher.java
+++ b/src/main/java/net/obvj/junit/utils/matchers/ExceptionMatcher.java
@@ -149,8 +149,8 @@ public class ExceptionMatcher extends TypeSafeDiagnosingMatcher<Procedure>
         /**
          * Validates the throwable's message.
          *
-         * @param parent    the {@link ExceptionMatcher} instance to be handled
-         * @param throwable the Throwable whose message is to be validated
+         * @param parent    the {@code ExceptionMatcher} instance to be handled
+         * @param throwable the {@code Throwable} whose message is to be validated
          * @param mismatch  the description to be used for reporting in case of mismatch
          * @return a flag indicating whether or not the matching has succeeded
          */
@@ -170,15 +170,14 @@ public class ExceptionMatcher extends TypeSafeDiagnosingMatcher<Procedure>
     private enum CauseMatchingStrategy
     {
         /**
-         * Validates if a that the cause matches a given class.
+         * Validates that the cause matches (or is assignable from) a given class.
          *
          * @since 1.6.0
          */
         EXPECTED_CLASS
         {
             @Override
-            boolean validateCause(ExceptionMatcher parent, Throwable throwable,
-                    Description mismatch)
+            boolean validateCause(ExceptionMatcher parent, Throwable throwable, Description mismatch)
             {
                 Throwable cause = throwable.getCause();
                 if (cause == null && parent.expectedCause != null)
@@ -194,7 +193,6 @@ public class ExceptionMatcher extends TypeSafeDiagnosingMatcher<Procedure>
                     return false;
                 }
                 return true;
-
             }
 
             @Override
@@ -207,15 +205,14 @@ public class ExceptionMatcher extends TypeSafeDiagnosingMatcher<Procedure>
         },
 
         /**
-         * Uses an external matcher to validate the cause of an exception.
+         * Uses a nested {@code ExceptionMatcher} to validate the cause of an exception.
          *
          * @since 1.6.0
          */
-        EXTERNAL_MATCHER
+        NESTED_MATCHER
         {
             @Override
-            boolean validateCause(ExceptionMatcher parent, Throwable throwable,
-                    Description mismatch)
+            boolean validateCause(ExceptionMatcher parent, Throwable throwable, Description mismatch)
             {
                 Procedure causeThrowingProcedure = new Procedure()
                 {
@@ -228,8 +225,7 @@ public class ExceptionMatcher extends TypeSafeDiagnosingMatcher<Procedure>
                 boolean matcherResult = parent.causeMatcher.matches(causeThrowingProcedure);
                 if (!matcherResult)
                 {
-                    mismatch.appendText(NEW_LINE_INDENT)
-                            .appendText("the cause did not match: (");
+                    mismatch.appendText(NEW_LINE_INDENT).appendText("the cause did not match: (");
                     parent.causeMatcher.describeMismatch(causeThrowingProcedure, mismatch);
                     mismatch.appendText(NEW_LINE_INDENT).appendText("}");
                 }
@@ -248,8 +244,8 @@ public class ExceptionMatcher extends TypeSafeDiagnosingMatcher<Procedure>
         /**
          * Validates the throwable's cause.
          *
-         * @param parent    the {@link ExceptionMatcher} instance to be handled
-         * @param throwable the Throwable whose message is to be validated
+         * @param parent    the {@code ExceptionMatcher} instance to be handled
+         * @param throwable the {@code Throwable} whose message is to be validated
          * @param mismatch  the description to be used for reporting in case of mismatch
          * @return a flag indicating whether or not the matching has succeeded
          */
@@ -359,8 +355,8 @@ public class ExceptionMatcher extends TypeSafeDiagnosingMatcher<Procedure>
      * This method behaves exactly the same as calling
      * {@link ExceptionMatcher#throwsException(Class)}.
      * <p>
-     * It was created primarily to allow a nested {@code ExceptionMatcher} for the cause of an
-     * exception.
+     * It was created primarily to allow a nested {@code ExceptionMatcher} to validate the
+     * cause of an exception.
      * <p>
      * For example:
      *
@@ -374,7 +370,7 @@ public class ExceptionMatcher extends TypeSafeDiagnosingMatcher<Procedure>
      *
      * @param exception the expected exception class. A null value is allowed, and means that
      *                  no exception is expected
-     * @return the matcher
+     * @return a new matcher
      * @since 1.6.0
      * @see ExceptionMatcher#throwsException(Class)
      */
@@ -441,7 +437,7 @@ public class ExceptionMatcher extends TypeSafeDiagnosingMatcher<Procedure>
      * specified class.
      * </p>
      *
-     * @param cause the expected cause; not null
+     * @param cause the expected cause
      * @return the matcher, incremented with a given cause for testing
      * @since 1.1.0
      */
@@ -476,7 +472,7 @@ public class ExceptionMatcher extends TypeSafeDiagnosingMatcher<Procedure>
     {
         causeMatcher = matcher;
         checkCauseFlag = true;
-        causeMatchingStrategy = CauseMatchingStrategy.EXTERNAL_MATCHER;
+        causeMatchingStrategy = CauseMatchingStrategy.NESTED_MATCHER;
         return this;
     }
 

--- a/src/test/java/net/obvj/junit/utils/matchers/AdvancedMatchersTest.java
+++ b/src/test/java/net/obvj/junit/utils/matchers/AdvancedMatchersTest.java
@@ -88,6 +88,16 @@ public class AdvancedMatchersTest
         },
         throwsException(IOException.class).withMessage("invalid"));
     }
+    
+    @Test
+    public void exception_procedureThrowingCheckedException_success()
+    {
+        assertThat(() ->
+        {
+            throw new ReflectiveOperationException("message");
+        },
+        exception(ReflectiveOperationException.class).withMessage("message"));
+    }
 
     @Test
     public void containsAll_moreThanOneString_createStringMatcherAccordingly()

--- a/src/test/java/net/obvj/junit/utils/matchers/ExceptionMatcherTest.java
+++ b/src/test/java/net/obvj/junit/utils/matchers/ExceptionMatcherTest.java
@@ -208,14 +208,14 @@ public class ExceptionMatcherTest
 
 
     @Test
-    public void withCause_nullAndNoCause_succeeds()
+    public void withNoCause_nullAndNoCause_succeeds()
     {
         assertThat(() -> RUNNABLE_THROWS_IAE_WITH_NO_CAUSE_AND_NO_MESSAGE.run(),
                 throwsException(IllegalArgumentException.class).withNoCause());
     }
 
     @Test(expected = AssertionError.class)
-    public void withCause_nullButHasCause_fails()
+    public void withNoCause_nullButHasCause_fails()
     {
         assertThat(() -> RUNNABLE_THROWS_IAE_WITH_CAUSE_NPE.run(),
                 throwsException(IllegalArgumentException.class).withNoCause());

--- a/src/test/java/net/obvj/junit/utils/matchers/ExceptionMatcherTest.java
+++ b/src/test/java/net/obvj/junit/utils/matchers/ExceptionMatcherTest.java
@@ -16,8 +16,7 @@
 
 package net.obvj.junit.utils.matchers;
 
-import static net.obvj.junit.utils.matchers.ExceptionMatcher.throwsException;
-import static net.obvj.junit.utils.matchers.ExceptionMatcher.throwsNoException;
+import static net.obvj.junit.utils.matchers.ExceptionMatcher.*;
 import static net.obvj.junit.utils.matchers.StringMatcher.containsAny;
 import static org.hamcrest.CoreMatchers.either;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -29,7 +28,6 @@ import java.io.IOException;
 
 import org.hamcrest.Matcher;
 import org.junit.Test;
-
 /**
  * Unit tests for the {@link ExceptionMatcher} class.
  *
@@ -42,6 +40,8 @@ public class ExceptionMatcherTest
     private static final String MESSAGE1 = "message1";
     private static final String MESSAGE2 = "message2";
     private static final String MESSAGE_ERR_0001_FULL = "[ERR-0001] message1";
+    private static final String IAE_MESSAGE = "iae message";
+    private static final String NPE_MESSAGE = "npe message";
     private static final String NULL_STRING = null;
 
     private static final Runnable RUNNABLE_THROWS_ISE_WITH_MESSAGE_AND_NO_CAUSE = () ->
@@ -56,7 +56,7 @@ public class ExceptionMatcherTest
 
     private static final Runnable RUNNABLE_THROWS_IAE_WITH_CAUSE_NPE = () ->
     {
-        throw new IllegalArgumentException(new NullPointerException());
+        throw new IllegalArgumentException(IAE_MESSAGE, new NullPointerException(NPE_MESSAGE));
     };
 
     private static final Runnable RUNNABLE_THROWS_IAE_WITH_NO_CAUSE_AND_NO_MESSAGE = () ->
@@ -164,17 +164,61 @@ public class ExceptionMatcherTest
     }
 
     @Test
+    public void withCause_causeMatcherAndCorrectCauseClass_succeeds()
+    {
+        assertThat(() -> RUNNABLE_THROWS_IAE_WITH_CAUSE_NPE.run(),
+                throwsException(IllegalArgumentException.class)
+                        .withCause(exception(NullPointerException.class)));
+    }
+
+    @Test
+    public void withCause_causeMatcherAndCauseClassIsChild_succeeds()
+    {
+        assertThat(() -> RUNNABLE_THROWS_IAE_WITH_CAUSE_NPE.run(),
+                throwsException(IllegalArgumentException.class)
+                        .withCause(exception(RuntimeException.class)));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void withCause_causeMatcherAndIncorrectCauseClass_succeeds()
+    {
+        assertThat(() -> RUNNABLE_THROWS_IAE_WITH_CAUSE_NPE.run(),
+                throwsException(IllegalArgumentException.class)
+                        .withCause(exception(FileNotFoundException.class)));
+    }
+
+    @Test
+    public void withCause_causeMatcherAndCorrectCauseClassAndMessage_succeeds()
+    {
+        assertThat(() -> RUNNABLE_THROWS_IAE_WITH_CAUSE_NPE.run(),
+                throwsException(IllegalArgumentException.class)
+                        .withMessage(IAE_MESSAGE)
+                        .withCause(exception(NullPointerException.class)
+                                .withMessage(NPE_MESSAGE)));
+    }
+
+    @Test(expected = AssertionError.class)
+    public void withCause_causeMatcherAndCorrectCauseClassAndIncorrectMessage_succeeds()
+    {
+        assertThat(() -> RUNNABLE_THROWS_IAE_WITH_CAUSE_NPE.run(),
+                throwsException(IllegalArgumentException.class)
+                        .withCause(exception(NullPointerException.class)
+                                .withMessage(IAE_MESSAGE)));
+    }
+
+
+    @Test
     public void withCause_nullAndNoCause_succeeds()
     {
         assertThat(() -> RUNNABLE_THROWS_IAE_WITH_NO_CAUSE_AND_NO_MESSAGE.run(),
-                throwsException(IllegalArgumentException.class).withCause(null));
+                throwsException(IllegalArgumentException.class).withNoCause());
     }
 
     @Test(expected = AssertionError.class)
     public void withCause_nullButHasCause_fails()
     {
         assertThat(() -> RUNNABLE_THROWS_IAE_WITH_CAUSE_NPE.run(),
-                throwsException(IllegalArgumentException.class).withCause(null));
+                throwsException(IllegalArgumentException.class).withNoCause());
     }
 
     @Test


### PR DESCRIPTION
## Enhancement

The purpose of this enhancement is to allow nesting another `ExceptionMatcher` to be used inside `ExceptionMatcher.withCause()` so that the following instruction could be possible:

````java
 assertThat(() -> obj.doStuff("p1"),
         throwsException(IllegalArgumentException.class)
             .withCause(exception(FileNotFoundException.class).withMessage("File p1 not found")));
````


## Quality criteria
The following criteria will be observed during the Code Review:

#### Code coverage
- The produced code shall be secured by unit tests.
- Test coverage shall remain the same (100%).
#### Documentation
- All methods shall be documented with **Javadoc**, providing examples of usage.
- Javadoc pages shall be compilable with no warnings