### PR TITLE
Introduce new ExceptionMatcher.with(...)

### DIFF
--- a/src/main/java/net/obvj/junit/utils/matchers/ExceptionMatcher.java
+++ b/src/main/java/net/obvj/junit/utils/matchers/ExceptionMatcher.java
@@ -263,6 +263,25 @@ public class ExceptionMatcher extends TypeSafeDiagnosingMatcher<Procedure>
         abstract void describeTo(ExceptionMatcher parent, Description description);
     }
 
+    /**
+     * A simple association between a function and a matcher, to extract and validate custom data
+     * from a throwable.
+     *
+     * @since 1.8.0
+     */
+    private static class CustomFunction
+    {
+        private final Function<? super Throwable, Object> function;
+        private final Matcher<?> matcher;
+
+        private CustomFunction(Function<? super Throwable, Object> function, Matcher<?> matcher)
+        {
+            this.function = function;
+            this.matcher = matcher;
+        }
+    }
+
+
     private static final String INDENT = "          ";
     private static final String NEW_LINE_INDENT = "\n" + INDENT;
 
@@ -281,17 +300,6 @@ public class ExceptionMatcher extends TypeSafeDiagnosingMatcher<Procedure>
 
     private List<CustomFunction> customFunctions;
 
-    private static class CustomFunction
-    {
-        private final Function<? super Throwable, Object> function;
-        private final Matcher<?> matcher;
-
-        private CustomFunction(Function<? super Throwable, Object> function, Matcher<?> matcher)
-        {
-            this.function = function;
-            this.matcher = matcher;
-        }
-    }
 
     /**
      * Builds this Matcher.

--- a/src/main/java/net/obvj/junit/utils/matchers/MyCustomException.java
+++ b/src/main/java/net/obvj/junit/utils/matchers/MyCustomException.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024 obvj.net
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.obvj.junit.utils.matchers;
 
 public class MyCustomException extends Exception

--- a/src/main/java/net/obvj/junit/utils/matchers/MyCustomException.java
+++ b/src/main/java/net/obvj/junit/utils/matchers/MyCustomException.java
@@ -1,0 +1,27 @@
+package net.obvj.junit.utils.matchers;
+
+public class MyCustomException extends Exception
+{
+    private static final long serialVersionUID = 5725758277733721926L;
+
+    private final String customString;
+    private final int code;
+
+    public MyCustomException(String message, String customString, int code)
+    {
+        super(message);
+        this.customString = customString;
+        this.code = code;
+    }
+
+    public String getCustomString()
+    {
+        return customString;
+    }
+
+    public int getCode()
+    {
+        return code;
+    }
+
+}


### PR DESCRIPTION
This enhancement introduces a method to allow the extraction of custom exception data by accepting functions or lambda expressions. For example:

````java
assertThat(() ->
{
    throw new MyCustomException(MESSAGE1, ERR_0001, 1910);
},
throwsException(MyCustomException.class)
        .with(MyCustomException::getCustomString, equalTo(ERR_0001))
        .with(MyCustomException::getCode, equalTo(1910))
        .with(MyCustomException::getLocalizedMessage, endsWith(MESSAGE2)));
````

It can be combined with existing methods. For example:

````java
assertThat(() ->
{
    throw new MyCustomException(MESSAGE1, ERR_0001, 1910);
},
throwsException(MyCustomException.class)
        .with(MyCustomException::getCustomString, equalTo(ERR_0001))
        .with(MyCustomException::getCode, equalTo(1910))
        .withMessageContaining(MESSAGE2)
        .withCause(...));
````