### PR TITLE
New StringMatcher.containsAllInSequence

### DIFF
--- a/src/main/java/net/obvj/junit/utils/matchers/AdvancedMatchers.java
+++ b/src/main/java/net/obvj/junit/utils/matchers/AdvancedMatchers.java
@@ -284,6 +284,39 @@ public class AdvancedMatchers
     }
 
     /**
+     * Creates a matcher that matches if the examined string contains <b>all</b> of the
+     * specified substrings in order.
+     * <p>
+     * For example:
+     *
+     * <blockquote>
+     * <pre>
+     * assertThat("the quick brown fox", containsAllInSequence("the", "fox")) //PASS
+     * assertThat("the quick brown fox", containsAllInSequence("fox", "the")) //FAIL
+     * </pre>
+     * </blockquote>
+     *
+     * By default, the matcher is <b>case-sensitive</b>, but this behavior can be modified
+     * with an additional method call.
+     * <p>
+     * For example:
+     *
+     * <blockquote>
+     * <pre>
+     * assertThat("the quick brown fox", containsAllInSequence("QUICK", "brown").ignoreCase())
+     * </pre>
+     * </blockquote>
+     *
+     * @param substrings the substrings to be tested
+     * @return the matcher
+     * @since 1.9.0
+     */
+    public static StringMatcher containsAllInSequence(String... substrings)
+    {
+        return StringMatcher.containsAllInSequence(substrings);
+    }
+
+    /**
      * Creates a matcher that matches if the examined string contains <b>any</b> of the
      * specified substrings.
      * <p>

--- a/src/main/java/net/obvj/junit/utils/matchers/StringMatcher.java
+++ b/src/main/java/net/obvj/junit/utils/matchers/StringMatcher.java
@@ -64,7 +64,9 @@ public class StringMatcher extends TypeSafeDiagnosingMatcher<String>
         },
 
         /**
-         * Matches if all of the specified substrings are found in the tested string in the sequence they are declared.
+         * Matches if all of the specified substrings are found in the tested string in the
+         * sequence they are declared.
+         *
          * @since 1.9.0
          */
         ALL_IN_SEQUENCE
@@ -215,8 +217,18 @@ public class StringMatcher extends TypeSafeDiagnosingMatcher<String>
          */
         public abstract boolean contains(String string, String substring);
 
-
-        public abstract int indexOf(String string, String substring, int startIndex);
+        /**
+         * Returns the index of the first occurrence of the specified substring within the
+         * specified string, starting at the specified index.
+         *
+         * @param string    the string to check
+         * @param substring the substring to search for
+         * @param fromIndex the index from which to start the search
+         * @return the index the index of the first occurrence of the specified substring within
+         *         the specified string, starting at the specified index
+         * @since 1.9.0
+         */
+        public abstract int indexOf(String string, String substring, int fromIndex);
     }
 
     private final Strategy strategy;

--- a/src/main/java/net/obvj/junit/utils/matchers/StringMatcher.java
+++ b/src/main/java/net/obvj/junit/utils/matchers/StringMatcher.java
@@ -33,6 +33,7 @@ public class StringMatcher extends TypeSafeDiagnosingMatcher<String>
 {
     private static final String EXPECTED_SCENARIO = "a string containing %s of the specified substrings %s";
     private static final String EXPECTED_STRING_NOT_FOUND = "the substring \"%s\" was not found in: \"%s\"";
+    private static final String EXPECTED_STRING_NOT_FOUND_AFTER = "the substring \"%s\" was not found after \"%s\" in: \"%s\"";
     private static final String NONE_OF_THE_STRINGS_FOUND = "none of the specified substrings was found in: \"%s\"";
     private static final String UNEXPECTED_STRING_FOUND = "the unexpected string \"%s\" was found in: \"%s\"";
 
@@ -59,6 +60,47 @@ public class StringMatcher extends TypeSafeDiagnosingMatcher<String>
                     }
                 }
                 return true;
+            }
+        },
+
+        /**
+         * Matches if all of the specified substrings are found in the tested string in the sequence they are declared.
+         * @since 1.9.0
+         */
+        ALL_IN_SEQUENCE
+        {
+            @Override
+            public boolean evaluate(String string, List<String> substrings, CaseStrategy caseStrategy,
+                    Description mismatch)
+            {
+                int lastIndex = -1;
+                for (int i = 0; i < substrings.size(); i++)
+                {
+                    String substring = substrings.get(i);
+                    int currentIndex = caseStrategy.indexOf(string,  substring, lastIndex + 1);
+
+                    if (currentIndex == -1)
+                    {
+                        if (i == 0)
+                        {
+                            mismatch.appendText(String.format(EXPECTED_STRING_NOT_FOUND, substring, string));
+                        }
+                        else
+                        {
+                            mismatch.appendText(String.format(EXPECTED_STRING_NOT_FOUND_AFTER, substring, substrings.get(i - 1), string));
+                        }
+                        return false;
+                    }
+
+                    lastIndex = currentIndex + substring.length() - 1;
+                }
+                return true;
+            }
+
+            @Override
+            public String toString()
+            {
+                return "ALL (in sequence)";
             }
         },
 
@@ -131,6 +173,12 @@ public class StringMatcher extends TypeSafeDiagnosingMatcher<String>
             {
                 return string != null && substring != null && string.contains(substring);
             }
+
+            @Override
+            public int indexOf(String string, String substring, int fromIndex)
+            {
+                return string != null ? string.indexOf(substring, fromIndex): -1;
+            }
         },
 
         /**
@@ -142,6 +190,12 @@ public class StringMatcher extends TypeSafeDiagnosingMatcher<String>
             public boolean contains(String string, String substring)
             {
                 return string != null && substring != null && string.toLowerCase().contains(substring.toLowerCase());
+            }
+
+            @Override
+            public int indexOf(String string, String substring, int fromIndex)
+            {
+                return string != null && substring != null ? string.toLowerCase().indexOf(substring.toLowerCase(), fromIndex): -1;
             }
         };
 
@@ -160,6 +214,9 @@ public class StringMatcher extends TypeSafeDiagnosingMatcher<String>
          * @return {@code true} if the string contains the substring, otherwise {@code false}
          */
         public abstract boolean contains(String string, String substring);
+
+
+        public abstract int indexOf(String string, String substring, int startIndex);
     }
 
     private final Strategy strategy;
@@ -197,6 +254,26 @@ public class StringMatcher extends TypeSafeDiagnosingMatcher<String>
     public static StringMatcher containsAll(String... substrings)
     {
         return new StringMatcher(Strategy.ALL, CaseStrategy.DEFAULT, substrings);
+    }
+
+    /**
+     * Creates a matcher that matches if the examined string contains <b>all</b> of the
+     * specified substrings in order.
+     * <p>
+     * For example:
+     *
+     * <pre>
+     * assertThat("the quick brown fox", containsAllInSequence("quick", "brown")) //PASS
+     * assertThat("the quick brown fox", containsAllInSequence("brown", "quick")) //FAIL
+     * </pre>
+     *
+     * @param substrings the substrings to be tested
+     * @return the matcher
+     * @since 1.9.0
+     */
+    public static StringMatcher containsAllInSequence(String... substrings)
+    {
+        return new StringMatcher(Strategy.ALL_IN_SEQUENCE, CaseStrategy.DEFAULT, substrings);
     }
 
     /**

--- a/src/test/java/net/obvj/junit/utils/matchers/AdvancedMatchersTest.java
+++ b/src/test/java/net/obvj/junit/utils/matchers/AdvancedMatchersTest.java
@@ -119,6 +119,14 @@ class AdvancedMatchersTest
     }
 
     @Test
+    void containsAllInSequence_moreThanOneString_createStringMatcherAccordingly()
+    {
+        StringMatcher matcher = containsAllInSequence(STRING1, STRING2);
+        assertThat(matcher.getStrategy(), is(equalTo(Strategy.ALL_IN_SEQUENCE)));
+        assertThat(matcher.getSubstrings(), is(equalTo(Arrays.asList(STRING1, STRING2))));
+    }
+
+    @Test
     void containsAny_moreThanOneString_createStringMatcherAccordingly()
     {
         StringMatcher matcher = containsAny(STRING1, STRING2);

--- a/src/test/java/net/obvj/junit/utils/matchers/StringMatcherTest.java
+++ b/src/test/java/net/obvj/junit/utils/matchers/StringMatcherTest.java
@@ -16,11 +16,14 @@
 
 package net.obvj.junit.utils.matchers;
 
-import static net.obvj.junit.utils.matchers.StringMatcher.containsAll;
-import static net.obvj.junit.utils.matchers.StringMatcher.containsAny;
-import static net.obvj.junit.utils.matchers.StringMatcher.containsNone;
+import static net.obvj.junit.utils.matchers.StringMatcher.*;
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -96,6 +99,47 @@ class StringMatcherTest
     {
         assertThrows(AssertionError.class,
                 () -> assertThat(THE_QUICK_BROWN_FOX, containsAll(DRAGON).ignoreCase()));
+    }
+
+    @Test
+    void containsAllInSequence_oneSubstringOnlyAndFound_success()
+    {
+        assertThat(THE_QUICK_BROWN_FOX, containsAllInSequence(FOX));
+    }
+
+    @Test
+    void containsAllInSequence_oneSubstringOnlyAndNotFound_fails()
+    {
+        AssertionError error = assertThrows(AssertionError.class,  () -> assertThat(THE_QUICK_BROWN_FOX, containsAllInSequence(DRAGON)));
+        assertLines(error.getMessage(), "", "Expected: a string containing ALL (in sequence) of the specified substrings [dragon]",
+                "     but: the substring \"dragon\" was not found in: \"" + THE_QUICK_BROWN_FOX + "\"");
+    }
+
+    @Test
+    void containsAllInSequence_twoSubstringsAndBothFoundInSequenceFar_success()
+    {
+        assertThat(THE_QUICK_BROWN_FOX, containsAllInSequence(FOX, DOG));
+    }
+
+    @Test
+    void containsAllInSequence_twoSubstringsAndBothFoundInSequenceClose_success()
+    {
+        assertThat(THE_QUICK_BROWN_FOX, containsAllInSequence("lazy", " dog"));
+    }
+
+    @Test
+    void containsAllInSequence_secondSubstringNotInSequence_fails()
+    {
+        AssertionError error = assertThrows(AssertionError.class,  () -> assertThat(THE_QUICK_BROWN_FOX, containsAllInSequence(DOG, FOX)));
+        assertLines(error.getMessage(), "", "Expected: a string containing ALL (in sequence) of the specified substrings [dog, fox]",
+                "     but: the substring \"fox\" was not found after \"dog\" in: \"" + THE_QUICK_BROWN_FOX + "\"");
+    }
+
+    void assertLines(String actualString, String... expectedlines)
+    {
+        List<String> expectedLines = Arrays.asList(expectedlines);
+        List<String> actualStringAsList = Arrays.asList(actualString.split(System.getProperty("line.separator")));
+        assertLinesMatch(expectedLines, actualStringAsList);
     }
 
 }

--- a/src/test/java/net/obvj/junit/utils/matchers/StringMatcherTest.java
+++ b/src/test/java/net/obvj/junit/utils/matchers/StringMatcherTest.java
@@ -16,8 +16,10 @@
 
 package net.obvj.junit.utils.matchers;
 
-import static net.obvj.junit.utils.matchers.StringMatcher.*;
-import static org.hamcrest.CoreMatchers.*;
+import static net.obvj.junit.utils.matchers.StringMatcher.containsAll;
+import static net.obvj.junit.utils.matchers.StringMatcher.containsAllInSequence;
+import static net.obvj.junit.utils.matchers.StringMatcher.containsAny;
+import static net.obvj.junit.utils.matchers.StringMatcher.containsNone;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertLinesMatch;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -110,8 +112,10 @@ class StringMatcherTest
     @Test
     void containsAllInSequence_oneSubstringOnlyAndNotFound_fails()
     {
-        AssertionError error = assertThrows(AssertionError.class,  () -> assertThat(THE_QUICK_BROWN_FOX, containsAllInSequence(DRAGON)));
-        assertLines(error.getMessage(), "", "Expected: a string containing ALL (in sequence) of the specified substrings [dragon]",
+        AssertionError error = assertThrows(AssertionError.class,
+                () -> assertThat(THE_QUICK_BROWN_FOX, containsAllInSequence(DRAGON)));
+        assertLines(error.getMessage(), "",
+                "Expected: a string containing ALL (in sequence) of the specified substrings [dragon]",
                 "     but: the substring \"dragon\" was not found in: \"" + THE_QUICK_BROWN_FOX + "\"");
     }
 
@@ -128,10 +132,18 @@ class StringMatcherTest
     }
 
     @Test
+    void containsAllInSequence_twoSubstringsAndBothFoundInSequenceAndIgnoreCase_success()
+    {
+        assertThat(THE_QUICK_BROWN_FOX, containsAllInSequence("QUICK", "BROWN").ignoreCase());
+    }
+
+    @Test
     void containsAllInSequence_secondSubstringNotInSequence_fails()
     {
-        AssertionError error = assertThrows(AssertionError.class,  () -> assertThat(THE_QUICK_BROWN_FOX, containsAllInSequence(DOG, FOX)));
-        assertLines(error.getMessage(), "", "Expected: a string containing ALL (in sequence) of the specified substrings [dog, fox]",
+        AssertionError error = assertThrows(AssertionError.class,
+                () -> assertThat(THE_QUICK_BROWN_FOX, containsAllInSequence(DOG, FOX)));
+        assertLines(error.getMessage(), "",
+                "Expected: a string containing ALL (in sequence) of the specified substrings [dog, fox]",
                 "     but: the substring \"fox\" was not found after \"dog\" in: \"" + THE_QUICK_BROWN_FOX + "\"");
     }
 


### PR DESCRIPTION
This adds a new Matcher that matches if the examined string contains <b>all</b> of thespecified substrings in order.
For example:

````java
assertThat("the quick brown fox", containsAllInSequence("the", "fox")) //PASS
assertThat("the quick brown fox", containsAllInSequence("fox", "the")) //FAIL
assertThat("the quick brown fox", containsAllInSequence("QUICK", "brown").ignoreCase()) //PASS
````